### PR TITLE
fix: add retry logic, session reuse, and timeouts to prevent ConnectionResetError

### DIFF
--- a/tap_taxjar/streams.py
+++ b/tap_taxjar/streams.py
@@ -2,14 +2,40 @@
 
 from __future__ import annotations
 
+import time
 import typing as t
-from importlib import resources
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
+
 import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 from singer_sdk import typing as th
 
 from tap_taxjar.client import TaxJarStream
+
+REQUEST_TIMEOUT = 30
+MAX_RETRIES = 5
+RETRY_BACKOFF_FACTOR = 1
+RETRY_STATUS_FORCELIST = (429, 500, 502, 503, 504)
+DETAIL_REQUEST_DELAY = 0.05
+
+
+def _build_session(auth_headers: dict) -> requests.Session:
+    """Build a requests.Session with retry/backoff on transient failures."""
+    session = requests.Session()
+    session.headers.update(auth_headers)
+    retry_strategy = Retry(
+        total=MAX_RETRIES,
+        backoff_factor=RETRY_BACKOFF_FACTOR,
+        status_forcelist=RETRY_STATUS_FORCELIST,
+        allowed_methods=["GET"],
+        raise_on_status=False,
+    )
+    adapter = HTTPAdapter(max_retries=retry_strategy)
+    session.mount("https://", adapter)
+    session.mount("http://", adapter)
+    return session
 
 
 class TransactionsStream(TaxJarStream):
@@ -56,29 +82,59 @@ class TransactionsStream(TaxJarStream):
 
     def get_records(self, context: dict | None) -> t.Iterable[dict]:
         days_back = self.config.get("days_back", 21)
-        start_date = datetime.utcnow() - timedelta(days=days_back)
-        end_date = datetime.utcnow()
+        start_date = datetime.now(timezone.utc) - timedelta(days=days_back)
+        end_date = datetime.now(timezone.utc)
         current_date = start_date
+
+        session = _build_session(self.authenticator.auth_headers)
 
         while current_date <= end_date:
             current_date_str = current_date.strftime("%Y/%m/%d")
             self.logger.info(f"Fetching transactions from {current_date_str}")
-            url = f"{self.url_base}/transactions/orders"
-            params = {
-                "transaction_date": current_date_str,
-                "provider": "upsellery"
-            }
-            headers = self.authenticator.auth_headers
-            resp = requests.get(url, headers=headers, params=params)
-            orders = resp.json()["orders"]
+
+            orders = self._fetch_order_ids(session, current_date_str)
             order_count = 0
+
             for order in orders:
-                params = {'provider': 'upsellery'}
-                detail_resp = requests.get(
-                    f"{self.url_base}/transactions/orders/{order}", headers=headers, params=params
-                )
-                if detail_resp.ok:
-                    order_count +=1
-                    yield detail_resp.json().get("order", {})
-            self.logger.info(f"Loaded {order_count} transactions from {current_date_str}")
+                record = self._fetch_order_detail(session, order)
+                if record is not None:
+                    order_count += 1
+                    yield record
+                time.sleep(DETAIL_REQUEST_DELAY)
+
+            self.logger.info(
+                f"Loaded {order_count} transactions from {current_date_str}"
+            )
             current_date += timedelta(days=1)
+
+        session.close()
+
+    def _fetch_order_ids(
+        self, session: requests.Session, date_str: str
+    ) -> list[str]:
+        """Fetch order IDs for a given date with retry handling."""
+        url = f"{self.url_base}/transactions/orders"
+        params = {
+            "transaction_date": date_str,
+            "provider": "upsellery",
+        }
+        resp = session.get(url, params=params, timeout=REQUEST_TIMEOUT)
+        resp.raise_for_status()
+        return resp.json()["orders"]
+
+    def _fetch_order_detail(
+        self, session: requests.Session, order_id: str
+    ) -> dict | None:
+        """Fetch a single order's detail with retry handling."""
+        url = f"{self.url_base}/transactions/orders/{order_id}"
+        params = {"provider": "upsellery"}
+        try:
+            resp = session.get(url, params=params, timeout=REQUEST_TIMEOUT)
+            resp.raise_for_status()
+            return resp.json().get("order", {})
+        except requests.exceptions.RequestException:
+            self.logger.warning(
+                f"Failed to fetch detail for order {order_id} after retries, "
+                "skipping."
+            )
+            return None


### PR DESCRIPTION
## fix: add retry logic, session reuse, and timeouts to prevent ConnectionResetError

### Problem

The `tap-taxjar` extractor has been failing daily with `ConnectionResetError: [Errno 104] Connection reset by peer` during transaction syncs. The error occurs at the `requests.get()` call in `streams.py:77 get_records()`, and has been observed on multiple consecutive days (2/26 run `cd7c1274`, 2/27 run `336f540b`).

**Root causes**
- **No retry logic** — a single transient `ConnectionResetError` kills the entire sync
- **No request timeouts** — connections can hang indefinitely
- **No session reuse** — every request opens a new TCP/SSL connection, increasing connection churn and susceptibility to resets
- **No error handling on the listing endpoint** — only the detail endpoint checked `.ok`
- **No backoff between requests** — rapid-fire API calls to TaxJar trigger rate limiting or connection drops

### Changes

**`tap_taxjar/streams.py`**
- Replaced raw `requests.get()` calls with a shared `requests.Session` backed by `urllib3.util.retry.Retry` (5 retries, exponential backoff on 429/5xx)
- Added 30s request timeout on all API calls
- TCP/SSL connections are now reused via the session's connection pool
- Added a small delay (`0.05s`) between detail requests to reduce API pressure
- Extracted `_fetch_order_ids()` and `_fetch_order_detail()` helper methods for clarity and testability
- Individual order detail failures are now gracefully skipped (logged as warnings) instead of crashing the entire sync
- Added `raise_for_status()` on the listing endpoint for proper error surfacing
- Fixed `datetime.utcnow()` deprecation with timezone-aware `datetime.now(timezone.utc)`
- 
### CI Check Failures

The 6 failing CI checks are **pre-existing and unrelated** to this PR:
- **pytest (3.9–3.13)**: `test_core.py` uses the SDK's built-in tap test class which attempts to discover/connect without a valid `api_key` configured in CI — this was already failing on `main` before this PR
- **Release / Build Wheel**: Packaging workflow that triggers on every push — not related to code changes
